### PR TITLE
Set titles of section for automatic toctree

### DIFF
--- a/docs/Code.rst
+++ b/docs/Code.rst
@@ -1,3 +1,7 @@
+==================
+Code documentation
+==================
+
 Initialization
 --------------
 

--- a/docs/Developing.rst
+++ b/docs/Developing.rst
@@ -1,11 +1,10 @@
-Contributing to the MVS development
-===================================
-
-CONTRIBUTING.md
----------------
+===================
+Contributing to MVS
+===================
 
 Proposed workflow
 -----------------
+The workflow is described in the CONTRIBUTING.md file in the repository
 
 Build documentation
 -------------------

--- a/docs/Installation.rst
+++ b/docs/Installation.rst
@@ -1,5 +1,6 @@
-Installation of MVS
-===================
+========================
+Getting started with MVS
+========================
 
 
 Setup process for users

--- a/docs/Overview.rst
+++ b/docs/Overview.rst
@@ -1,5 +1,6 @@
-Getting to know the Project
-===========================
+=================
+About the Project
+=================
 
 H2020 Project E-Land
 --------------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -3,6 +3,7 @@
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 
+========================================================
 Welcome to Multi-Vector Simulator (MVS)'s documentation!
 ========================================================
 
@@ -13,6 +14,7 @@ Welcome to Multi-Vector Simulator (MVS)'s documentation!
    Developing
    Code
 
+==================
 Indices and tables
 ==================
 


### PR DESCRIPTION
Fix #66 by correctly indenting the subtitles of each section of the docs